### PR TITLE
Fix missing os import in brain evolution example

### DIFF
--- a/examples/re_book/1_brain_evolution.py
+++ b/examples/re_book/1_brain_evolution.py
@@ -1,6 +1,7 @@
 # Standard libraries
 import gc
 import random
+import os
 import time
 from pathlib import Path
 from typing import Any, List, Literal, Optional, cast


### PR DESCRIPTION
Regarding issue: https://github.com/ci-group/ariel/issues/106

Adds the missing `os` import in
`examples/re_book/1_brain_evolution.py`.